### PR TITLE
Fix ClusterRolebinding

### DIFF
--- a/kubernetes.yaml
+++ b/kubernetes.yaml
@@ -38,6 +38,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: kubeedge-database
+  namespace: default
 
 ---
 apiVersion: v1


### PR DESCRIPTION
Otherwise you will get the following error:

```bash
The ClusterRoleBinding "kubeedge-database" is invalid: subjects[0].namespace: Required value
```

Tested with Kubernetes 1.16